### PR TITLE
[feat] 사용자 조건 기반 정책 추천 기능 구현 및 관련 리팩토링

### DIFF
--- a/src/main/java/com/arom/polisee/domain/gender/Gender.java
+++ b/src/main/java/com/arom/polisee/domain/gender/Gender.java
@@ -1,7 +1,0 @@
-package com.arom.polisee.domain.gender;
-
-public enum Gender {
-    Male,
-    Female,
-    BOTH
-}

--- a/src/main/java/com/arom/polisee/domain/policies/entity/Policies.java
+++ b/src/main/java/com/arom/polisee/domain/policies/entity/Policies.java
@@ -1,7 +1,7 @@
 package com.arom.polisee.domain.policies.entity;
 
 
-import com.arom.polisee.domain.policy_detail.entity.PoliciyDetail;
+import com.arom.polisee.domain.policy_detail.entity.PolicyDetail;
 import com.arom.polisee.domain.policies.dto.PoliciesDTO;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -14,147 +14,110 @@ import lombok.Setter;
 public class Policies {
 
     @Id
-    @Column(name = "service_id")
     private String id;
 
     // Policies와 1:1, PK 공유
 
-    @OneToOne(mappedBy = "policyRequirements", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
-    private PoliciyDetail policiyDetail;
+    @OneToOne(mappedBy = "policies", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
+    private PolicyDetail policyDetail;
 
     // 서비스명
-    @Column(name = "service_name")
     private String serviceName;
 
-    @Column(name = "male")
     private String male;
 
-    @Column(name = "female")
     private String female;
 
-    @Column(name = "start_age")
     private Integer startAge;
 
-    @Column(name = "end_age")
     private Integer endAge;
 
-    @Column(name = "median_income_0~50%")
     private String medianIncome0To50;
 
-    @Column(name = "median_income_51~75%")
     private String medianIncome51To75;
 
-    @Column(name = "median_income_75~100%")
     private String medianIncome76To100;
 
-    @Column(name = "median_income_101~200%")
     private String medianIncome101To200;
 
-    @Column(name = "median_income_over_200%")
     private String medianIncomeOver200;
 
     // 예비부부/난임
-    @Column(name = "expectant_couple_or_infertility")
     private String expectantCoupleOrInfertility;
 
     // 임산부
-    @Column(name = "pregnant")
     private String pregnant;
 
     // 출산/입양
-    @Column(name = "adoption_or_childbirth")
     private String adoptionOrChildbirth;
 
     // 농업인
-    @Column(name = "farmer")
     private String farmer;
 
     // 어업인
-    @Column(name = "fishman")
-    private String fishman;
+    private String fisherman;
 
     // 축산업인
-    @Column(name = "livestock_farmer")
-    private String LivestockFarmer;
+    private String livestockFarmer;
 
     // 임업인
-    @Column(name = "forest_worker")
     private String forestWorker;
 
     // 초등학생
-    @Column(name = "elementary")
     private String elementary;
 
     // 중학생
-    @Column(name = "mid_school")
     private String midSchool;
 
     //고등학생
-    @Column(name = "high_school")
     private String highSchool;
 
     // 대학생/대학원생
-    @Column(name = "University")
     private String university;
 
     // 근로자/직장인
-    @Column(name = "employee")
     private String employee;
 
     // 구직자/실업자
-    @Column(name = "unemployed")
     private String unemployed;
 
     // 장애인
-    @Column(name = "disabled")
     private String disabled;
 
     // 국가보훈대상자
-    @Column(name = "national_merit")
     private String nationalMerit;
 
     // 질병/질환자
-    @Column(name = "sick")
     private String sick;
 
     // 해당사항 없음 (예비부부 부터 대학생까지)
-    @Column(name = "personality_nothing")
     private String personalityNothing;
 
     // 다문화가정
-    @Column(name = "multicultural")
     private String multicultural;
 
     // 북한이탈주민
-    @Column(name = "defector")
     private String defector;
 
     // 한부모가정
-    @Column(name = "single_parent")
     private String singleParent;
 
     // 1인가구
-    @Column(name = "solo")
     private String solo;
 
     // 다자녀가구
-    @Column(name = "many_children")
     private String manyChildren;
 
     // 무주택세대
-    @Column(name = "homeless")
     private String homeless;
 
     // 신규전입
-    @Column(name = "new_home")
     private String newHome;
 
     // 확대가족
-    @Column(name = "extended_family")
     private String extendedFamily;
 
     // 해당사항없음 (다문화가정부터 확대가족까지)
-    @Column(name = "family_nothing")
     private String familyNothing;
 
     public Policies fromDto(PoliciesDTO dto) {
@@ -172,7 +135,7 @@ public class Policies {
         setPregnant(dto.getJA0302());
         setAdoptionOrChildbirth(dto.getJA0303());
         setFarmer(dto.getJA0313());
-        setFishman(dto.getJA0314());
+        setFisherman(dto.getJA0314());
         setLivestockFarmer(dto.getJA0315());
         setForestWorker(dto.getJA0316());
         setElementary(dto.getJA0317());

--- a/src/main/java/com/arom/polisee/domain/policies/repository/EligiblePolicesRepository.java
+++ b/src/main/java/com/arom/polisee/domain/policies/repository/EligiblePolicesRepository.java
@@ -1,0 +1,11 @@
+package com.arom.polisee.domain.policies.repository;
+
+import com.arom.polisee.domain.policies.entity.Policies;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+
+public interface EligiblePolicesRepository extends JpaRepository<Policies, Long>,
+        JpaSpecificationExecutor<Policies> {
+}

--- a/src/main/java/com/arom/polisee/domain/policy_detail/entity/PolicyDetail.java
+++ b/src/main/java/com/arom/polisee/domain/policy_detail/entity/PolicyDetail.java
@@ -9,71 +9,66 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-public class PoliciyDetail {
+public class PolicyDetail {
     @Id
-    @Column(name = "service_id")
     private String id;  // PK
 
     @OneToOne
     @MapsId
-    @JoinColumn(name = "service_id")
+    @JoinColumn(name = "policies_id")
     private Policies policies;
 
-    @Column(name = "register_date")
     private String registerDate;   // 등록 일시
 
-    @Column(name = "department_name")
     private String departmentName;
 
-    @Column(name = "detail_url")
     private String detailUrl;
 
-    @Column(name = "service_purpose_summary")
     private String servicePurposeSummary;
 
-    @Column(name = "service_field") // 서비스분야
+    // 서비스분야
     private String serviceField;
 
-    @Column(name = "selection_criteria", columnDefinition = "TEXT") // 선정기준
+    @Column(columnDefinition = "TEXT") // 선정기준
     private String selectionCriteria;
 
-    @Column(name = "agency_name") // 소관기관명
+    // 소관기관명
     private String agencyName;
 
-    @Column(name = "agency_type") // 소관기관유형
+    // 소관기관유형
     private String agencyType;
 
-    @Column(name = "agency_code") // 소관기관코드
+    // 소관기관코드
     private String agencyCode;
 
-    @Column(name = "updated_datetime") // 수정일시
-    private String updatedDatetime; // 수정 일시 (문자열 예시)
+    // 수정일시
+    private String updatedDatetime;
 
-    @Column(name = "application_deadline") // 신청기한
+    // 신청기한
     private String applicationDeadline;
 
-    @Column(name = "application_method", columnDefinition = "TEXT") // 신청방법
+    @Column(columnDefinition = "TEXT") // 신청방법
     private String applicationMethod;
 
-    @Column(name = "contact_number",columnDefinition = "TEXT") // 전화문의
+    @Column(columnDefinition = "TEXT") // 전화문의
     private String contactNumber;
 
-    @Column(name = "reception_agency") // 접수기관
+    // 접수기관
     private String receptionAgency;
 
-    @Column(name = "view_count") // 조회수
+    // 조회수
     private Integer viewCount; // 정수형 조회수
 
-    @Column(name = "support_contents", columnDefinition = "TEXT") // 지원내용
+    @Column(columnDefinition = "TEXT") // 지원내용
     private String supportContents;
 
-    @Column(name = "support_target", columnDefinition = "TEXT") // 지원대상
+    @Column(columnDefinition = "TEXT") // 지원대상
     private String supportTarget;
 
-    @Column(name = "support_type") // 지원유형
+    // 지원유형
     private String supportType;
 
-    public PoliciyDetail fromDto(PoliciyDetailDTO dto) {
+    public PolicyDetail fromDto(PoliciyDetailDTO dto) {
         this.setRegisterDate(dto.getRegisterDate());
         this.setDepartmentName(dto.getDepartmentName());
         this.setDetailUrl(dto.getDetailUrl());

--- a/src/main/java/com/arom/polisee/domain/policy_detail/repository/PoliciyDetailRepository.java
+++ b/src/main/java/com/arom/polisee/domain/policy_detail/repository/PoliciyDetailRepository.java
@@ -1,6 +1,6 @@
 package com.arom.polisee.domain.policy_detail.repository;
 
-import com.arom.polisee.domain.policy_detail.entity.PoliciyDetail;
+import com.arom.polisee.domain.policy_detail.entity.PolicyDetail;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.extern.slf4j.Slf4j;
@@ -15,15 +15,15 @@ public class PoliciyDetailRepository {
     @PersistenceContext
     private EntityManager em;
 
-    public void save(PoliciyDetail policy) {
+    public void save(PolicyDetail policy) {
         em.persist(policy);
     }
 
-    public void saveAll(List<PoliciyDetail> policies) {
-        for (PoliciyDetail policy : policies) save(policy);
+    public void saveAll(List<PolicyDetail> policies) {
+        for (PolicyDetail policy : policies) save(policy);
     }
 
-    public PoliciyDetail findByPolicyId(String policyId) {
-        return em.find(PoliciyDetail.class, policyId);
+    public PolicyDetail findByPolicyId(String policyId) {
+        return em.find(PolicyDetail.class, policyId);
     }
 }

--- a/src/main/java/com/arom/polisee/domain/policy_detail/service/PoliciyDetailService.java
+++ b/src/main/java/com/arom/polisee/domain/policy_detail/service/PoliciyDetailService.java
@@ -1,7 +1,7 @@
 package com.arom.polisee.domain.policy_detail.service;
 
 import com.arom.polisee.domain.api.dto.PolicyDetailResponseDto;
-import com.arom.polisee.domain.policy_detail.entity.PoliciyDetail;
+import com.arom.polisee.domain.policy_detail.entity.PolicyDetail;
 import com.arom.polisee.domain.policy_detail.repository.PoliciyDetailRepository;
 import com.arom.polisee.domain.policies.entity.Policies;
 import com.arom.polisee.domain.policies.repository.PoliciesRepository;
@@ -60,7 +60,7 @@ public class PoliciyDetailService {
                 return false;
             }
 
-            List<PoliciyDetail> policiyDetailList = response.getData().stream()
+            List<PolicyDetail> policyDetailList = response.getData().stream()
                     .map(dto -> {
                         Optional<Policies> policyRequirements = policiesRepository.findById(dto.getId());
 
@@ -70,16 +70,16 @@ public class PoliciyDetailService {
                             return null;
                         }
 
-                        PoliciyDetail policiyDetail = new PoliciyDetail();
-                        policiyDetail.setId(policyRequirements.get().getId());
-                        policiyDetail.fromDto(dto);
-                        policiyDetail.setPolicies(policyRequirements.get());
-                        return policiyDetail;
+                        PolicyDetail policyDetail = new PolicyDetail();
+                        policyDetail.setId(policyRequirements.get().getId());
+                        policyDetail.fromDto(dto);
+                        policyDetail.setPolicies(policyRequirements.get());
+                        return policyDetail;
                     })
                     .filter(Objects::nonNull) // null 값 제거
                     .toList();
 
-            policiyDetailRepository.saveAll(policiyDetailList);
+            policiyDetailRepository.saveAll(policyDetailList);
             return true;
 
         } catch (Exception e) {

--- a/src/main/java/com/arom/polisee/domain/recommend_policies/RecommendPolicies.java
+++ b/src/main/java/com/arom/polisee/domain/recommend_policies/RecommendPolicies.java
@@ -14,7 +14,7 @@ import lombok.Setter;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uq_user_policy",
-                        columnNames = {"user_id", "service_id"}
+                        columnNames = {"user_id", "policies_id"}
                 )
         }
 )
@@ -22,14 +22,13 @@ public class RecommendPolicies extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "recommend_id")
-    private Long recommendId;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne
-    @JoinColumn(name = "service_id", nullable = false)
+    @JoinColumn(name = "policies_id", nullable = false)
     private Policies policies;
 }

--- a/src/main/java/com/arom/polisee/domain/recommend_policies/controller/RecommendController.java
+++ b/src/main/java/com/arom/polisee/domain/recommend_policies/controller/RecommendController.java
@@ -1,0 +1,27 @@
+package com.arom.polisee.domain.recommend_policies.controller;
+
+import com.arom.polisee.domain.recommend_policies.service.RecommendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/recommend")
+public class RecommendController {
+
+    private final RecommendService recommendService;
+
+    @GetMapping("/{userId}")
+    public List<String> recommendPolicies(@PathVariable Long userId) {
+        return recommendService.matchEligiblePolicies(userId);
+    }
+}
+

--- a/src/main/java/com/arom/polisee/domain/recommend_policies/repository/RecommendPoliciesRepository.java
+++ b/src/main/java/com/arom/polisee/domain/recommend_policies/repository/RecommendPoliciesRepository.java
@@ -1,0 +1,9 @@
+package com.arom.polisee.domain.recommend_policies.repository;
+
+import com.arom.polisee.domain.policies.entity.Policies;
+import com.arom.polisee.domain.recommend_policies.RecommendPolicies;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendPoliciesRepository extends JpaRepository<RecommendPolicies, Long>{
+
+}

--- a/src/main/java/com/arom/polisee/domain/recommend_policies/service/PolicySpecification.java
+++ b/src/main/java/com/arom/polisee/domain/recommend_policies/service/PolicySpecification.java
@@ -1,0 +1,63 @@
+package com.arom.polisee.domain.recommend_policies.service;
+
+import com.arom.polisee.domain.policies.entity.Policies;
+import com.arom.polisee.domain.userInfo.UserInfo;
+import org.springframework.data.jpa.domain.Specification;
+
+public class PolicySpecification {
+
+    // 성별
+    public static Specification<Policies> matchGender(UserInfo user) {
+        return (root, query, builder) -> {
+            if (user.getGender() == UserInfo.Gender.MALE)        return builder.equal(root.get("male"), "Y");
+            else if (user.getGender() == UserInfo.Gender.FEMALE) return builder.equal(root.get("female"), "Y");
+
+            return builder.conjunction();
+        };
+    }
+
+    // 나이
+    public static Specification<Policies> matchAge(UserInfo user) {
+        return (root, query, builder) -> builder.and(
+                builder.lessThanOrEqualTo(root.get("startAge"), user.getAge()),
+                builder.greaterThanOrEqualTo(root.get("endAge"), user.getAge())
+        );
+    }
+
+    // 중위 소득
+    public static Specification<Policies> matchMedianIncome(UserInfo user) {
+        if (user.getMedianIncome() == null) {
+            return (root, query, builder) -> builder.conjunction();
+        }
+
+        return (root, query, builder) -> {
+            switch (user.getMedianIncome()) {
+                case MEDIAN_INCOME_0_TO_50:     return builder.equal(root.get("medianIncome0To50"), "Y");
+                case MEDIAN_INCOME_51_TO_75:    return builder.equal(root.get("medianIncome51To75"), "Y");
+                case MEDIAN_INCOME_76_TO_100:   return builder.equal(root.get("medianIncome76To100"), "Y");
+                case MEDIAN_INCOME_101_TO_200:  return builder.equal(root.get("medianIncome101To200"), "Y");
+                case MEDIAN_INCOME_OVER_200:    return builder.equal(root.get("medianIncomeOver200"), "Y");
+                default:                        return builder.disjunction();
+            }
+        };
+    }
+
+    // 자녀 유무
+    public static Specification<Policies> matchHasChildren(UserInfo user) {
+        if (user.getHasChildren() == null)
+            return (root, query, builder) -> builder.conjunction();
+
+        return (root, query, builder) -> {
+            switch (user.getHasChildren()) {
+                case EXPECTANT_COUPLE_OR_INFERTILITY:
+                    return builder.equal(root.get("expectantCoupleOrInfertility"), "Y");
+                case PREGNANT:
+                    return builder.equal(root.get("pregnant"), "Y");
+                case ADOPTION_OR_CHILDBIRTH:
+                    return builder.equal(root.get("adoptionOrChildbirth"), "Y");
+                default:
+                    return builder.disjunction();
+            }
+        };
+    }
+}

--- a/src/main/java/com/arom/polisee/domain/recommend_policies/service/RecommendService.java
+++ b/src/main/java/com/arom/polisee/domain/recommend_policies/service/RecommendService.java
@@ -1,0 +1,117 @@
+package com.arom.polisee.domain.recommend_policies.service;
+
+import com.arom.polisee.domain.policies.entity.Policies;
+import com.arom.polisee.domain.policies.repository.EligiblePolicesRepository;
+import com.arom.polisee.domain.recommend_policies.RecommendPolicies;
+import com.arom.polisee.domain.recommend_policies.repository.RecommendPoliciesRepository;
+import com.arom.polisee.domain.userInfo.UserInfo;
+import com.arom.polisee.domain.userInfo.repository.UserInfoRepository;
+import com.arom.polisee.global.exception.BaseException;
+import com.arom.polisee.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RecommendService {
+
+    private final EligiblePolicesRepository eligiblePolicesRepository;
+    private final UserInfoRepository userInfoRepository;
+    private final RecommendPoliciesRepository recommendPoliciesRepository;
+
+    public List<String> matchEligiblePolicies(Long userId) {
+        UserInfo userInfo = userInfoRepository.findById(userId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.USER_NOT_FOUND));
+
+        // DB에서 1차 필터링된 정책들만 조회
+        Specification<Policies> spec = Specification.where(PolicySpecification.matchGender(userInfo))
+                .and(PolicySpecification.matchAge(userInfo))
+                .and(PolicySpecification.matchMedianIncome(userInfo))
+                .and(PolicySpecification.matchHasChildren(userInfo));
+
+        List<Policies> policiesList = eligiblePolicesRepository.findAll(spec);
+
+        List<String> eligiblePolicyIds = new ArrayList<>();
+
+        for (Policies policy : policiesList) {
+            if (isCompletelyEligible(userInfo, policy)) {
+                registerRecommendPolicy(userInfo, policy);
+                eligiblePolicyIds.add(policy.getId());
+            }
+        }
+        return eligiblePolicyIds;
+    }
+
+    public void registerRecommendPolicy(UserInfo userInfo, Policies policy) {
+        RecommendPolicies recommendPolicy = new RecommendPolicies();
+        recommendPolicy.setUser(userInfo.getUser());
+        recommendPolicy.setPolicies(policy);
+        recommendPoliciesRepository.save(recommendPolicy);
+    }
+
+    public boolean isCompletelyEligible(UserInfo userInfo, Policies policy) {
+        if (userInfo.getOccupationType() != null && !isOccupationEligible(userInfo, policy)) return false;
+        if (userInfo.getFamilyType() != null && !isFamilyTypeEligible(userInfo, policy)) return false;
+        if (userInfo.getHouseholdType() != null && !isHouseholdTypeEligible(userInfo, policy)) return false;
+        if (!isJobOrStudyStatusEligible(userInfo, policy)) return false;
+        return true;
+    }
+
+    private boolean isEligible(String policyField) {
+        return "Y".equals(policyField);
+    }
+
+    // 직종 분류 체크
+    private boolean isOccupationEligible(UserInfo user, Policies policy) {
+        switch (user.getOccupationType()) {
+            case FARMER:            return isEligible(policy.getFarmer());
+            case FISHERMAN:         return isEligible(policy.getFisherman());
+            case LIVESTOCK_FARMER:  return isEligible(policy.getLivestockFarmer());
+            case FOREST_WORKER:     return isEligible(policy.getForestWorker());
+            default:                return false;
+        }
+    }
+
+    // 가족 형태 체크
+    private boolean isFamilyTypeEligible(UserInfo user, Policies policy) {
+        switch (user.getFamilyType()) {
+            case PERSONALITY_NOTHING:   return isEligible(policy.getPersonalityNothing());
+            case MULTICULTURAL:         return isEligible(policy.getMulticultural());
+            case DEFECTOR:              return isEligible(policy.getDefector());
+            case SINGLE_PARENT:         return isEligible(policy.getSingleParent());
+            default:                    return false;
+        }
+    }
+
+    // 가구 형태 체크
+    private boolean isHouseholdTypeEligible(UserInfo user, Policies policy) {
+        switch (user.getHouseholdType()) {
+            case SOLO:              return isEligible(policy.getSolo());
+            case MANY_CHILDREN:     return isEligible(policy.getManyChildren());
+            case HOMELESS:          return isEligible(policy.getHomeless());
+            case NEW_HOME:          return isEligible(policy.getNewHome());
+            case EXTENDED_FAMILY:   return isEligible(policy.getExtendedFamily());
+            case FAMILY_NOTHING:    return isEligible(policy.getFamilyNothing());
+            default:                return false;
+        }
+    }
+
+    // 직업/학업 상태 체크
+    private boolean isJobOrStudyStatusEligible(UserInfo user, Policies policy) {
+        switch (user.getJobOrStudyStatus()) {
+            case ELEMENTARY:    return isEligible(policy.getElementary());
+            case MIDSCHOOL:     return isEligible(policy.getMidSchool());
+            case HIGHSCHOOL:    return isEligible(policy.getHighSchool());
+            case UNIVERSITY:    return isEligible(policy.getUniversity());
+            case EMPLOYEE:      return isEligible(policy.getEmployee());
+            case UNEMPLOYED:    return isEligible(policy.getUnemployed());
+            default:            return false;
+        }
+    }
+}

--- a/src/main/java/com/arom/polisee/domain/user/User.java
+++ b/src/main/java/com/arom/polisee/domain/user/User.java
@@ -1,16 +1,13 @@
 package com.arom.polisee.domain.user;
 
+import com.arom.polisee.domain.recommend_policies.RecommendPolicies;
 import com.arom.polisee.domain.userInfo.UserInfo;
 import com.arom.polisee.global.entity.BaseEntity;
-import com.arom.polisee.domain.recommend_policies.RecommendPolicies;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,40 +15,27 @@ import java.util.List;
 @Getter
 @Setter
 @Entity
-@Table(name = "user")
 public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
     private Long userId;
 
-    @Column(name = "kakao_id", nullable = false)
+    @Column(nullable = false)
     private Long kakaoId;
 
-    @Column(name = "user_name", nullable = false, length = 50)
+    @Column(nullable = false, length = 50)
     private String userName;
 
-    @Column(name = "role", nullable = false)
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(name = "created_at", updatable = false)
-    @CreationTimestamp
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    @UpdateTimestamp
-    private LocalDateTime updatedAt;
-
-    // 1) user_info와 1:1
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, optional = false, fetch = FetchType.LAZY)
     private UserInfo userInfo;
 
-    // 2) user_recommend_policy 와 1:N
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecommendPolicies> recommendPolicies = new ArrayList<>();
 }
-
 
 

--- a/src/main/java/com/arom/polisee/domain/userInfo/UserInfo.java
+++ b/src/main/java/com/arom/polisee/domain/userInfo/UserInfo.java
@@ -1,22 +1,20 @@
 package com.arom.polisee.domain.userInfo;
 
 
-import com.arom.polisee.domain.gender.Gender;
 import com.arom.polisee.domain.user.User;
 import com.arom.polisee.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "user_info")
 public class UserInfo extends BaseEntity {
 
     @Id
-    @Column(name = "id")
     private Long id;
 
     @OneToOne
@@ -24,40 +22,90 @@ public class UserInfo extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "성별", length = 10)
-    private Gender gender;
+    @Enumerated(EnumType.STRING) private Gender gender;
 
-    @Column(name = "나이")
     private Integer age;
 
-    @Column(name = "user_residence(시)")
     private String userResidenceSi;
 
-    @Column(name = "user_residence(구)")
     private String userResidenceGu;
 
-    @Column(name = "중위소득")
-    private String medianIncome;
+    //중위소득
+    @Enumerated(EnumType.STRING) private MedianIncome medianIncome;
 
-    @Column(name = "자녀유무")
-    private String hasChildren;
+    //자녀유무
+    @Enumerated(EnumType.STRING) private HasChildren hasChildren;
 
-    @Column(name = "직업 및 학업 상태")
-    private String jobAndStudyStatus;
+    //직종분류
+    @Enumerated(EnumType.STRING) private OccupationType occupationType;
 
-    @Column(name = "근로상태여부")
-    private String employmentCondition;
+    //직업 및 학업 상태
+    @NonNull @Enumerated(EnumType.STRING) private JobOrStudyStatus jobOrStudyStatus;
 
-    @Column(name = "가족 형태")
-    private String familyType;
+    //근로상태여부
+    //private String employmentCondition;
 
-    @Column(name = "가구 형태")
-    private String householdType;
+    //가족 형태
+    @Enumerated(EnumType.STRING) private FamilyType familyType;
 
-    @Column(name = "장애인/질병")
+    //가구 형태
+    @Enumerated(EnumType.STRING) private HouseholdType householdType;
+
+    //장애인/질병
     private String disabledOrDisease;
 
-    @Column(name = "복지대상자")
+    //복지대상자
     private String welfareTarget;
+
+    public enum Gender {
+        MALE,
+        FEMALE
+    }
+
+    public enum MedianIncome {
+        MEDIAN_INCOME_0_TO_50,
+        MEDIAN_INCOME_51_TO_75,
+        MEDIAN_INCOME_76_TO_100,
+        MEDIAN_INCOME_101_TO_200,
+        MEDIAN_INCOME_OVER_200
+    }
+
+    public enum HasChildren {
+        EXPECTANT_COUPLE_OR_INFERTILITY,
+        PREGNANT,
+        ADOPTION_OR_CHILDBIRTH
+    }
+
+    public enum OccupationType {
+        FARMER,              // 농업인
+        FISHERMAN,           // 어업인
+        LIVESTOCK_FARMER,    // 축산업인
+        FOREST_WORKER        // 임업인
+    }
+
+    public enum JobOrStudyStatus {
+        ELEMENTARY,
+        MIDSCHOOL,
+        HIGHSCHOOL,
+        UNIVERSITY,
+        EMPLOYEE,
+        UNEMPLOYED
+    }
+
+    public enum FamilyType {
+        PERSONALITY_NOTHING,   // 해당사항 없음
+        MULTICULTURAL,         // 다문화가정
+        DEFECTOR,              // 북한이탈주민
+        SINGLE_PARENT          // 한부모가정
+    }
+
+    public enum HouseholdType {
+        SOLO,              // 1인가구
+        MANY_CHILDREN,     // 다자녀가구
+        HOMELESS,          // 무주택세대
+        NEW_HOME,          // 신규전입
+        EXTENDED_FAMILY,   // 확대가족
+        FAMILY_NOTHING     // 해당사항 없음 (다문화가정부터 확대가족까지)
+    }
+
 }

--- a/src/main/java/com/arom/polisee/domain/userInfo/repository/UserInfoRepository.java
+++ b/src/main/java/com/arom/polisee/domain/userInfo/repository/UserInfoRepository.java
@@ -1,0 +1,9 @@
+package com.arom.polisee.domain.userInfo.repository;
+
+import com.arom.polisee.domain.userInfo.UserInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     generate-ddl: true
     show-sql: false
     open-in-view: false


### PR DESCRIPTION
# 이슈
- #3 

# 구현 기능

- 사용자 정보를 기반으로 정책을 필터링하여 맞춤형 **정책 추천 기능 구현**
    - `Specification`을 활용하여 유저 일부 정보를 조건으로 `DB`에서 `1차`로 동적 `필터링`된 `정책 목록`을 `조회`
    - 조회된 정책 중 최종적으로 지원 가능한 정책만 선별하여 맞춤 정책 추천 리스트에 저장

- `UserInfo` 엔티티 주요 필드(`enum`) 리팩토링
    - 성별, 소득, 자녀 여부 등 정책 필터링에 필요한 필드들을 enum으로 적용

- 기존 `Gender enum` 패키지 -> UserInfo 엔티티 내부로 통합 (도메인 기반 패키지 구조에 맞춰 제거)

- 엔티티 필드 및 컬럼명 오타 수정 및 리팩토링

# 작업 시간
